### PR TITLE
Support for django Translator object

### DIFF
--- a/cmsplugin_markup/cms_plugins.py
+++ b/cmsplugin_markup/cms_plugins.py
@@ -68,7 +68,7 @@ class MarkupPlugin(CMSPluginBase):
         return super(MarkupPlugin, self).add_view(request, form_url, extra_context=extra_context);
 
     def get_plugin_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        from django.conf.urls import patterns, url
 
         # If django-cms has get_plugin_urls feature or not
         urls = getattr(super(MarkupPlugin, self), 'get_plugin_urls', lambda: [])()

--- a/cmsplugin_markup/models.py
+++ b/cmsplugin_markup/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.utils.safestring import mark_safe
 from django.utils.html import strip_tags
-from django.utils.text import truncate_words
+from django.utils.text import Truncator
 from django.conf import settings
 from cms.models import CMSPlugin
 
@@ -27,7 +27,7 @@ class MarkupField(CMSPlugin):
     search_fields = ('body_html',)
 
     def __unicode__(self):
-        return u'%s' %(truncate_words(strip_tags(self.body_html), 3)[:30]+'...')
+        return Truncator(strip_tags(self.body_html)).chars(30, html=True)
 
     def save(self, *args, **kwargs):
         # We store it in any case to also check the parser for possible exceptions and to use it for __unicode__

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ if __name__ == '__main__':
         include_package_data = True,
         zip_safe = False,
         install_requires = [
-            'Django>=1.2',
-            'Markdown>=2',
-            'Textile>=2.1',
-            'docutils>=0.7',
-            'django-cms>=2.2',
+            'Django>1.4',
+            'Markdown>2',
+            'Textile>2.1',
+            'docutils>0.7',
+            'django-cms>3.0',
         ],
     )


### PR DESCRIPTION
Hi,

I am upgrading to django-cms 3.0 and django 1.6 and we are using your plugin. However it did not passed due to usage of truncatewords which is deprecated. I am not sure if this works 100%, bt can you kindly review and possibly merge into your mainline?
