### PR TITLE
Add a 'html' plugin...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,8 @@ supports Markdown_, reST_ and Textile_ markup languages.
 .. _reST: http://docutils.sourceforge.net/rst.html
 .. _Textile: http://textile.sitemonks.com/
 
+There is also a `html` dummy plugin, to add html code directly into a cms page.
+
 Documentation is found at:
 
 http://cmsplugin-markup.readthedocs.org/

--- a/cmsplugin_markup/plugins/html/__init__.py
+++ b/cmsplugin_markup/plugins/html/__init__.py
@@ -1,0 +1,10 @@
+
+from cmsplugin_markup.plugins import MarkupBase
+
+class Markup(MarkupBase):
+
+    name = 'Pure HTML'
+    identifier = 'html'
+
+    def parse(self, value, context=None, placeholder=None):
+        return value

--- a/cmsplugin_markup/plugins/html/__init__.py
+++ b/cmsplugin_markup/plugins/html/__init__.py
@@ -3,7 +3,7 @@ from cmsplugin_markup.plugins import MarkupBase
 
 class Markup(MarkupBase):
 
-    name = 'Pure HTML'
+    name = 'Raw HTML'
     identifier = 'html'
 
     def parse(self, value, context=None, placeholder=None):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,7 @@ can inject javascript code!
 To activate, just add it in your settings::
 
     CMS_MARKUP_OPTIONS = (
-        'cmsplugin_markup.plugins.html', # WARNING: javascript code injection!
+        'cmsplugin_markup.plugins.html', # WARNING: javascript code injection will be possible!
         ...
     )
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,8 @@ supports Markdown_, reST_ and Textile_ markup languages.
 .. _reST: http://docutils.sourceforge.net/rst.html
 .. _Textile: http://textile.sitemonks.com/
 
+There is also a `html` dummy plugin, to add html code directly into a cms page.
+
 Installation
 ------------
 
@@ -35,6 +37,35 @@ This will also allow markup plugins to handle their own additional URLs under
 above base URL.
 
 .. _PyPi: http://pypi.python.org/pypi
+
+Add this to your settings::
+
+    MIGRATION_MODULES = {
+        'cmsplugin_markup': 'cmsplugin_markup.migrations_django',
+    }
+    CMS_MARKUP_OPTIONS = (
+        'cmsplugin_markup.plugins.markdown',
+        'cmsplugin_markup.plugins.textile',
+        'cmsplugin_markup.plugins.restructuredtext',
+    )
+    CMS_MARKUP_RENDER_ALWAYS = True
+
+    CMS_MARKDOWN_EXTENSIONS = ()
+
+html plugin
+-----------
+
+You can insert html source code with the `html` plugin.
+
+Big warning: If you also activate the `html` plugin, every user with page permissions
+can inject javascript code!
+
+To activate, just add it in your settings::
+
+    CMS_MARKUP_OPTIONS = (
+        'cmsplugin_markup.plugins.html', # WARNING: javascript code injection!
+        ...
+    )
 
 Markup Plugins
 --------------

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup, find_packages
 
-VERSION = '0.2.4'
+VERSION = '0.3.0'
 
 if __name__ == '__main__':
     setup(
@@ -32,7 +32,7 @@ if __name__ == '__main__':
         zip_safe = False,
         test_suite = "runtests.runtests",
         install_requires = [
-            'Django>1.4',
+            'Django>1.4,<=1.8',
             'Markdown>2',
             'Textile>2.1',
             'docutils>0.7',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,9 +2,16 @@
 import os
 import tempfile
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    "django.core.context_processors.request",
-)
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'DIRS': [],
+    'APP_DIRS': True,
+    'OPTIONS': {
+        'context_processors': [
+            'django.core.context_processors.request',
+        ],
+    },
+},]
 MIDDLEWARE_CLASSES = ()
 
 LANGUAGE_CODE = "en"
@@ -20,7 +27,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sites',
 
-    'mptt',
+    'treebeard',
     "cms",
 
     "cmsplugin_markup",
@@ -37,7 +44,6 @@ DATABASES = {
 }
 
 MIGRATION_MODULES = {
-    'cms': 'cms.migrations_django',
     'cmsplugin_markup': 'cmsplugin_markup.migrations_django',
 }
 


### PR DESCRIPTION
With https://github.com/jedie/cmsplugin-markup/commit/f7390ef1a9ac918a58bdf97da7d19aa190410bb0 i have add a simple **html** plugin...

I also add big warnings, because every user with page permissions can inject javascript code. So it should be only activated in "safe" setups.

It's a little but useless for the most users?!? On the other side, this "plugin" is very little code.

(I used my **CI** branch as base. Because without it, i can't test it and unittest are also not there)
